### PR TITLE
Correctly hash int-arrays

### DIFF
--- a/src/main/java/me/jellysquid/mods/hydrogen/common/cache/BakedQuadCache.java
+++ b/src/main/java/me/jellysquid/mods/hydrogen/common/cache/BakedQuadCache.java
@@ -1,5 +1,7 @@
 package me.jellysquid.mods.hydrogen.common.cache;
 
+import java.util.Arrays;
+
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 
 public class BakedQuadCache {

--- a/src/main/java/me/jellysquid/mods/hydrogen/common/cache/BakedQuadCache.java
+++ b/src/main/java/me/jellysquid/mods/hydrogen/common/cache/BakedQuadCache.java
@@ -1,11 +1,13 @@
 package me.jellysquid.mods.hydrogen.common.cache;
 
-import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 
 public class BakedQuadCache {
-    private static final ObjectOpenHashSet<int[]> CACHE = new ObjectOpenHashSet<>();
+    private static final Int2ObjectOpenHashMap<int[]> CACHE = new Int2ObjectOpenHashMap<>();
 
     public synchronized static int[] dedup(int[] data) {
-        return CACHE.addOrGet(data);
+        int[] ret = CACHE.putIfAbsent(Arrays.hashCode(data), data);
+        if(ret == null)ret = data;
+        return ret;
     }
 }


### PR DESCRIPTION
Arrays can't be compared using .hashcode()/equals(), so the ObjectOpenHashSet will create an entry for each array. Now using a Map<int, int[]> and the correct Arrays.hashCode(...) to compute the hashcode.