### PR TITLE
Drop minimum Minecraft version to 1.16.4

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -29,6 +29,6 @@
   "depends": {
     "fabricloader": ">=0.9.0",
     "fabric-resource-loader-v0": ">=0.4",
-    "minecraft": "1.16.5"
+    "minecraft": ">=1.16.4"
   }
 }


### PR DESCRIPTION
1.16.5 is just a server side focused version, not sure if major changes that might break this mod if ran on 1.16.4 were made in 1.16.5