### PR TITLE
Simplify class define tool to call java 16's api explicitly

### DIFF
--- a/src/main/java/me/jellysquid/mods/hydrogen/common/jvm/ClassDefineTool.java
+++ b/src/main/java/me/jellysquid/mods/hydrogen/common/jvm/ClassDefineTool.java
@@ -1,39 +1,17 @@
 package me.jellysquid.mods.hydrogen.common.jvm;
 
-import jdk.dynalink.linker.support.Lookup;
 import org.apache.commons.io.IOUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
-import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
 import java.net.URL;
 
 public class ClassDefineTool {
-    private static final MethodHandles.Lookup LOOKUP;
-
-    private static final MethodHandle DEFINE_CLASS_METHOD;
-    private static final MethodHandle PRIVATE_LOOKUP_IN_METHOD;
+    private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
 
     private static final Logger LOGGER = LogManager.getLogger("Hydrogen");
-
-    static {
-        LOOKUP = MethodHandles.lookup();
-
-        try {
-            PRIVATE_LOOKUP_IN_METHOD = LOOKUP.findStatic(MethodHandles.class, "privateLookupIn",
-                    MethodType.methodType(MethodHandles.Lookup.class, Class.class, MethodHandles.Lookup.class));
-
-            DEFINE_CLASS_METHOD = LOOKUP.findVirtual(MethodHandles.Lookup.class, "defineClass",
-                    MethodType.methodType(Class.class, byte[].class));
-        } catch (IllegalAccessException e) {
-            throw new RuntimeException("Couldn't access method", e);
-        } catch (NoSuchMethodException e) {
-            throw new RuntimeException("Couldn't locate method", e);
-        }
-    }
 
     public static Class<?> defineClass(Class<?> context, String name) {
         String path = "/" + name.replace('.', '/') + ".class";
@@ -54,9 +32,10 @@ public class ClassDefineTool {
         }
 
         try {
-            MethodHandles.Lookup privateLookup = (MethodHandles.Lookup) PRIVATE_LOOKUP_IN_METHOD.invokeExact((Class<?>) context, (MethodHandles.Lookup) LOOKUP);
-
-            return (Class<?>) DEFINE_CLASS_METHOD.invokeExact(privateLookup, (byte[]) code);
+            // The context class need to be in a module that exports and opens to ClassDefineTool
+            // Example: guava's automatic module exports and opens to everything
+            MethodHandles.Lookup privateLookup = MethodHandles.privateLookupIn(context, LOOKUP);
+            return privateLookup.defineClass(code);
         } catch (Throwable throwable) {
             throw new RuntimeException("Failed to define class", throwable);
         }


### PR DESCRIPTION
First, thank you for integrating #21 into 1.17!
When hydrogen was back on java 8, I used method handles to access new api methods that are absent in the jdk 8 api. Now, they are no longer necessary. Also added a short comment on what keeps this approach work.

<details>
<summary>
I built this branch locally; it runs well in the vanilla launcher.
</summary>

![image](https://user-images.githubusercontent.com/7806504/122626230-d694fb80-d06e-11eb-9a0f-393a3c1153c4.png)
</details>
