### PR TITLE
Hydrogen is incompatible with Optifine/Optifabric; make this combo illegal

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -29,5 +29,8 @@
     "fabricloader": ">=0.11.0",
     "fabric-resource-loader-v0": ">=0.4",
     "minecraft": "1.17"
+  },
+  "breaks": {
+    "optifabric": "*"
   }
 }


### PR DESCRIPTION
Make explicit the fact that Hydrogen and Optifine/Optifabric don't mix well. 

This is in response to issues #41, issue #43 where users got confused; and in acknowledgement that #20 is a 'wont fix'.